### PR TITLE
Added (i) ability to set random seed and (ii) output of recombination events

### DIFF
--- a/control.txt
+++ b/control.txt
@@ -19,4 +19,5 @@ KAPPA=1.1       							# Transition/transversion parameter for K2P model (defaul
 #LOSS_RATE = 0.001							# Frequency of gene losses relative to substitution rate (default = none)
 #MIN_DELTA  = 10							# Minimum length of recombining fragments (default = 1 nucleotide)	
 #EXP_COEFF = 18.1							# Probability of recombination depends on sequence divergence (default = no)
+#RSEED=1234                                 # Random seed for reproducibility (default = current system time milliseconds)
 

--- a/coresimul_master.py
+++ b/coresimul_master.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-
+import time
 
 version = sys.version
 
@@ -49,6 +49,7 @@ parameters["GAIN_RATE"]="none"
 parameters["LOSS_RATE"]="none"
 parameters["MIN_DELTA"]="1"
 parameters["EXP_COEFF"]="no"
+parameters["RSEED"]=round(time.time()*1000)
 
 f=open(control_file,"r")
 for l in f:
@@ -93,6 +94,7 @@ model = parameters["SUB_MODEL"]
 gain_rate=parameters["GAIN_RATE"]
 loss_rate = parameters["LOSS_RATE"]
 min_delta = parameters["MIN_DELTA"]
+rseed = parameters["RSEED"]
 
 if parameters["EXP_COEFF"] == "no" or parameters["EXP_COEFF"] == "n":
 	exp_coeff = "no"
@@ -222,7 +224,7 @@ print("MIN_DELTA=",min_delta)
 print("################\n")
 
 
-os.system("python " + loc + "simulation.py " + str(exp_coeff) + " " + min_delta + " " + loss_rate + " " + gain_rate + " " + model + " " + sub_rate + " "  + path_to_seq + " " + sub + " " + str(kappa) + " " + str(GC) + " " + str(L) +  " " + str(COEFF) + " " + str(DELTA) + " "  + str(coeff) + " " + path)
+os.system("python " + loc + "simulation.py " + str(rseed) + " " + str(exp_coeff) + " " + min_delta + " " + loss_rate + " " + gain_rate + " " + model + " " + sub_rate + " "  + path_to_seq + " " + sub + " " + str(kappa) + " " + str(GC) + " " + str(L) +  " " + str(COEFF) + " " + str(DELTA) + " "  + str(coeff) + " " + path)
 
 
 

--- a/simulation.py
+++ b/simulation.py
@@ -82,6 +82,11 @@ gain_rate = sys.argv[-12]
 loss_rate = sys.argv[-13] 
 min_delta = float(sys.argv[-14])
 exp_coeff = sys.argv[-15]
+rseed = sys.argv[-16]
+
+print("Setting random seed: " + str(rseed))
+random.seed(int(rseed))
+numpy.random.seed(int(rseed))
 
 if exp_coeff != "no":
 	exp_coeff = float(exp_coeff)

--- a/simulation.py
+++ b/simulation.py
@@ -4,6 +4,20 @@
 ########################################################################
 import math
 
+class Recombination:
+	def __init__(self, donor, acceptor, startpos, endpos):
+		self.donor = donor
+		self.acceptor = acceptor
+		self.startpos = startpos
+		self.endpos = endpos
+
+	def to_csv(self, sep=","):
+		return "{donor}{sep}{acceptor}{sep}{startpos}{sep}{endpos}\n".format(
+			sep=sep, donor=self.donor, acceptor=self.acceptor, startpos=self.startpos, endpos=self.endpos)	
+
+	def csv_header(sep=","):
+		return "Donor{sep}Acceptor{sep}Start position{sep}End position\n".format(sep=sep)	
+
  
 def mean( echantillon ) :
     size = len( echantillon )
@@ -523,6 +537,7 @@ NB = max(process.keys())
 ########  Simulate evolution with recombination
 
 print("Simulate evolution with recombination AND SELECTION")
+recombination_log = []
 
 LENGTH,LENGTH_CUMUL={},{}
 for node in branch:
@@ -707,6 +722,7 @@ while nb <= NB:
 					# No = recombination aborted, need to re-update MEGA to recombine somewhere else...
 					if exp_coeff == "no":
 						total_r +=1
+						recombination_log += [Recombination(donor, node, start, end)]
 						sequence[node] =   sequence[node][:start] + sequence[donor][start:end] + sequence[node][end:]
 						NU.append(nu)
 						LISTE_DELTA.append(new_delta)
@@ -765,6 +781,13 @@ print("total gene copies lost=",total_losses)
 
 
 #print(NU[:100])
+
+# Write recombination log
+
+with open(os.path.join(path, "recombinations.txt"), "w") as rlog:
+	rlog.write(Recombination.csv_header())
+	for recombination_event in recombination_log:
+		rlog.write(recombination_event.to_csv())
 
 h=open(path + "nu.txt","w")
 if len(NU)> 0:


### PR DESCRIPTION
Thanks for the awesome tool!

This pull request implements two additional features that might be useful when performing benchmarks based on data generated using CoreSimul:
* An additional parameter in the control file, RSEED, to set the random seed. In this way, reproducible results can be ensured (if CoreSimul is run twice with the same RSEED, then the same tree is generated). If no RSEED is set, the current system time in milliseconds is used.
* An additional output file is generated: recombinations.txt. This is a csv file containing the donor, acceptor, start position and end position of each recombination event.